### PR TITLE
Add support for already-listening sockets

### DIFF
--- a/capi/libuwebsockets.cpp
+++ b/capi/libuwebsockets.cpp
@@ -338,17 +338,36 @@ extern "C"
 
     void uws_app_listen_with_config(int ssl, uws_app_t *app, uws_app_listen_config_t config, uws_listen_handler handler, void *user_data)
     {
+        /* branching is getting untidy */
         if (ssl)
         {
             uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
-            uwsApp->listen(config.host, config.port, config.options, [handler, config, user_data](struct us_listen_socket_t *listen_socket)
-                           { handler((struct us_listen_socket_t *)listen_socket, config, user_data); });
+            if (config.fd) {
+                uwsApp->listen(
+                    config.options,
+                    [handler, config, user_data](struct us_listen_socket_t *listen_socket) {
+                        handler((struct us_listen_socket_t *)listen_socket, config, user_data);
+                    },
+                    config.fd);
+            } else {
+                uwsApp->listen(config.host, config.port, config.options, [handler, config, user_data](struct us_listen_socket_t *listen_socket)
+                               { handler((struct us_listen_socket_t *)listen_socket, config, user_data); });
+            }
         }
         else
         {
             uWS::App *uwsApp = (uWS::App *)app;
-            uwsApp->listen(config.host, config.port, config.options, [handler, config, user_data](struct us_listen_socket_t *listen_socket)
-                           { handler((struct us_listen_socket_t *)listen_socket, config, user_data); });
+            if (config.fd) {
+                uwsApp->listen(
+                    config.options,
+                    [handler, config, user_data](struct us_listen_socket_t *listen_socket) {
+                        handler((struct us_listen_socket_t *)listen_socket, config, user_data);
+                    },
+                    config.fd);
+            } else {
+                uwsApp->listen(config.host, config.port, config.options, [handler, config, user_data](struct us_listen_socket_t *listen_socket)
+                               { handler((struct us_listen_socket_t *)listen_socket, config, user_data); });
+            }
         }
     }
 

--- a/capi/libuwebsockets.h
+++ b/capi/libuwebsockets.h
@@ -90,7 +90,7 @@ extern "C"
 
     DLL_EXPORT typedef struct
     {
-
+        LIBUS_SOCKET_DESCRIPTOR fd;
         int port;
         const char *host;
         int options;

--- a/src/App.h
+++ b/src/App.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <charconv>
 #include <string_view>
+#include "libusockets.h"
 
 namespace uWS {
     /* Safari 15.0 - 15.3 has a completely broken compression implementation (client_no_context_takeover not
@@ -559,6 +560,18 @@ public:
     /* Port, options, callback */
     TemplatedApp &&listen(int port, int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler) {
         handler(httpContext ? httpContext->listen(nullptr, port, options) : nullptr);
+        return std::move(*this);
+    }
+    
+    /* callback, fd */
+    TemplatedApp &&listen(MoveOnlyFunction<void(us_listen_socket_t *)> &&handler, LIBUS_SOCKET_DESCRIPTOR fd) {
+        handler(httpContext ? httpContext->listen(fd, 0) : nullptr);
+        return std::move(*this);
+    }
+    
+    /* options, callback, fd */
+    TemplatedApp &&listen(int options, MoveOnlyFunction<void(us_listen_socket_t *)> &&handler, LIBUS_SOCKET_DESCRIPTOR fd) {
+        handler(httpContext ? httpContext->listen(fd, options) : nullptr);
         return std::move(*this);
     }
 

--- a/src/HttpContext.h
+++ b/src/HttpContext.h
@@ -25,6 +25,7 @@
 #include "HttpResponseData.h"
 #include "AsyncSocket.h"
 #include "WebSocketData.h"
+#include "libusockets.h"
 
 #include <string_view>
 #include <iostream>
@@ -466,6 +467,12 @@ public:
     us_listen_socket_t *listen(const char *path, int options) {
         return us_socket_context_listen_unix(SSL, getSocketContext(), path, options, sizeof(HttpResponseData<SSL>));
     }
+
+    /* Attach to bound and listening socket (fd) using this HttpContext */
+    us_listen_socket_t *listen(LIBUS_SOCKET_DESCRIPTOR fd, int options) {
+        return us_socket_context_listen_direct(SSL, getSocketContext(), fd, options, sizeof(HttpResponseData<SSL>));
+    }
+
 };
 
 }


### PR DESCRIPTION
This is the library backing for `Bun.serve({fd})` and `Bun.listen({fd})` (see https://github.com/oven-sh/bun/pull/2852)

This relies on changes to uSockets, but I didn't redirect the submodule. To build, either merge https://github.com/Jarred-Sumner/uSockets/pull/3 or use my fork: https://github.com/shivak/uSockets/tree/bun-direct.